### PR TITLE
Add tanimoto calculator and refine scaffold split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 *.pyc
 /models
 */__pycache__
-/notebooks
 /external/DeepChemStable
 /data/preprocessing
 **/*.log

--- a/scripts/filter_by_tanimoto.py
+++ b/scripts/filter_by_tanimoto.py
@@ -1,0 +1,117 @@
+import pandas as pd
+import pathlib
+import argparse
+import logging
+from src.data.tanimoto import TanimotoCalculator
+from src.data.featurizer import EcfpFeaturizer
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--test-path",
+        "-p",
+        type=str,
+        required=True,
+        help="Path to the test set CSV file",
+    )
+    parser.add_argument(
+        "--dir",
+        "-d",
+        type=str,
+        default=None,
+        help="Directory containing CSV files to filter "
+        "(default: same directory as test set)",
+    )
+    parser.add_argument(
+        "--threshold",
+        "-t",
+        type=float,
+        default=0.1,
+        help="Tanimoto distance threshold for filtering (default: 0.1)",
+    )
+    parser.add_argument(
+        "--discard-closer",
+        "-c",
+        action="store_true",
+        help="If set, discard molecules with Tanimoto distance less than the threshold",
+    )
+    parser.add_argument(
+        "--discard-further",
+        "-f",
+        action="store_true",
+        help="If set, discard molecules with Tanimoto distance greater than the threshold",
+    )
+    parser.add_argument(
+        "--inclusive",
+        "-i",
+        action="store_true",
+        help="If set, use inclusive comparison (<= or >=) when filtering",
+    )
+
+    args = parser.parse_args()
+    if args.discard_closer and args.discard_further:
+        raise ValueError(
+            "Cannot set both --discard-closer and --discard-further flags at the same time."
+        )
+    if not args.discard_closer and not args.discard_further:
+        raise ValueError("Must set either --discard-closer or --discard-further flag.")
+    test_set_path = pathlib.Path(args.test_set)
+    dir = test_set_path.parent if args.dir is None else pathlib.Path(args.dir)
+
+    # load test set smiles
+    test_df = pd.read_csv(test_set_path)
+    test_smiles = set(test_df["smiles"].tolist())
+
+    # configure logging
+    logging.basicConfig(
+        level=logging.INFO,
+        handlers=[
+            logging.FileHandler(dir / "drop_test_smiles.log"),
+            logging.StreamHandler(),
+        ],
+    )
+
+    # initialize tanimoto calculator
+    featurizer = EcfpFeaturizer(radius=2, n_bits=2048)
+    tanimoto_calculator = TanimotoCalculator(
+        featurizer=featurizer, smiles_list=list(test_smiles)
+    )
+
+    # collect all .csv files in the directory where the test set is located, except the test set itself
+    all_files = list(dir.glob("*.csv"))
+    all_files = [f for f in all_files if f.name != test_set_path.name]
+
+    # read each of the files file, delete smiles which are in the test set
+    for f in all_files:
+        logging.info(f"Processing {f.name}")
+        df = pd.read_csv(f)
+        original_count = len(df)
+        df["tanimoto_to_test_set"] = tanimoto_calculator.run_batch(
+            df["smiles"].tolist()
+        )["min_distance"]
+
+        if args.discard_closer:
+            if args.inclusive:
+                df = df[df["tanimoto_to_test_set"] >= args.threshold]
+                save_path = (
+                    dir / f"{f.stem}_further_than_{args.threshold}_inclusive{f.suffix}"
+                )
+            else:
+                df = df[df["tanimoto_to_test_set"] >= args.threshold]
+                save_path = dir / f"{f.stem}_further_than_{args.threshold}{f.suffix}"
+        else:
+            if args.inclusive:
+                df = df[df["tanimoto_to_test_set"] < args.threshold]
+                save_path = (
+                    dir / f"{f.stem}_closer_than_{args.threshold}_inclusive{f.suffix}"
+                )
+            else:
+                df = df[df["tanimoto_to_test_set"] <= args.threshold]
+                save_path = dir / f"{f.stem}_closer_than_{args.threshold}{f.suffix}"
+        filtered_count = len(df)
+        logging.info(
+            f"Processed {f.name}: {original_count} -> {filtered_count} molecules after filtering."
+        )
+        logging.info(f"Saving filtered dataset to {save_path}")
+        df.to_csv(save_path, index=False)
+    logging.info(f"Logs saved to {dir / 'drop_test_smiles.log'}")

--- a/scripts/filter_by_tanimoto.py
+++ b/scripts/filter_by_tanimoto.py
@@ -3,7 +3,6 @@ import pathlib
 import argparse
 import logging
 from src.data.tanimoto import TanimotoCalculator
-from src.data.featurizer import EcfpFeaturizer
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -72,10 +71,7 @@ if __name__ == "__main__":
     )
 
     # initialize tanimoto calculator
-    featurizer = EcfpFeaturizer(radius=2, n_bits=2048)
-    tanimoto_calculator = TanimotoCalculator(
-        featurizer=featurizer, smiles_list=list(test_smiles)
-    )
+    tanimoto_calculator = TanimotoCalculator(smiles_list=list(test_smiles))
 
     # collect all .csv files in the directory where the test set is located, except the test set itself
     all_files = list(dir.glob("*.csv"))

--- a/src/data/tanimoto.py
+++ b/src/data/tanimoto.py
@@ -1,18 +1,19 @@
-from typing import List, Tuple
+from typing import List
 import numpy as np
 from rdkit import DataStructs
 from rdkit.DataStructs import ExplicitBitVect
-
-from src import FeaturizerBase
+from src.data.featurizer import FeaturizerBase, EcfpFeaturizer
 
 
 class TanimotoCalculator:
-    """Efficiently calculate Tanimoto distance between a query molecule and a set of molecules."""
+    """Efficiently calculate Tanimoto distance between a query molecule and a set of molecules.
+    Uses ECFP4 fingerprints by default, but can be configured to use any featurizer compatible with FeaturizerBase.
+    """
 
     def __init__(
         self,
-        featurizer: FeaturizerBase,
         smiles_list: List[str],
+        featurizer: FeaturizerBase | None = None,
         return_closest_smiles: bool = False,
     ):
         """
@@ -21,7 +22,10 @@ class TanimotoCalculator:
             featurizer: An instance of FeaturizerBase to compute fingerprints
             smiles_list: List of SMILES strings representing the molecules to compare against
         """
-        self.featurizer = featurizer
+        if featurizer is None:
+            self.featurizer = EcfpFeaturizer(n_bits=1024, radius=2)
+        else:
+            self.featurizer = featurizer
         self.smiles_list = smiles_list
         self.fingerprints = self.precompute_fingerprints(smiles_list)
         self.return_closest_smiles = return_closest_smiles

--- a/src/data/tanimoto.py
+++ b/src/data/tanimoto.py
@@ -1,0 +1,118 @@
+from typing import List, Tuple
+import numpy as np
+from rdkit import DataStructs
+from rdkit.DataStructs import ExplicitBitVect
+
+from src import FeaturizerBase
+
+
+class TanimotoCalculator:
+    """Efficiently calculate Tanimoto distance between a query molecule and a set of molecules."""
+
+    def __init__(
+        self,
+        featurizer: FeaturizerBase,
+        smiles_list: List[str],
+        return_closest_smiles: bool = False,
+    ):
+        """
+        Initialize the calculator with a set of molecules.
+        Args:
+            featurizer: An instance of FeaturizerBase to compute fingerprints
+            smiles_list: List of SMILES strings representing the molecules to compare against
+        """
+        self.featurizer = featurizer
+        self.smiles_list = smiles_list
+        self.fingerprints = self.precompute_fingerprints(smiles_list)
+        self.return_closest_smiles = return_closest_smiles
+
+    def run_single(self, query: str) -> dict:
+        """
+        Calculate Tanimoto distances for the query molecule and return summary statistics.
+        Args:
+            query: SMILES string of the query molecule
+        Returns:
+            Dictionary containing max, min, mean, and quartiles of Tanimoto distances
+        """
+        query_fp = self.featurizer.featurize([query])[0]
+        similarities = self._calculate_similarities(query_fp)
+        distances = 1 - similarities
+
+        q1, q2, q3 = np.percentile(distances, [25, 50, 75])
+        stat_dict = {
+            "max_distance": float(np.max(distances)),
+            "min_distance": float(np.min(distances)),
+            "mean_distance": float(np.mean(distances)),
+            "q1_distance": float(q1),
+            "q2_distance": float(q2),
+            "q3_distance": float(q3),
+        }
+
+        if self.return_closest_smiles:
+            min_index = int(np.argmin(distances))
+            stat_dict["query_smile"] = query
+            stat_dict["closest_smile"] = self.smiles_list[min_index]
+
+        return stat_dict
+
+    def run_batch(self, queries: List[str]) -> dict:
+        """
+        Calculate Tanimoto distances for a batch of query molecules.
+        Args:
+            queries: List of SMILES strings of the query molecules
+        Returns:
+            Dictionary of lists containing summary statistics for each query
+        """
+        results = {
+            "max_distance": [],
+            "min_distance": [],
+            "mean_distance": [],
+            "q1_distance": [],
+            "q2_distance": [],
+            "q3_distance": [],
+            "query_smile": [],
+            "closest_smile": [],
+        }
+
+        for query in queries:
+            stats = self.run_single(query)
+            for key in results.keys():
+                results[key].append(stats[key])
+
+        if not self.return_closest_smiles:
+            results.pop("closest_smile")
+            results.pop("query_smile")
+
+        return results
+
+    def _calculate_similarities(self, query_fp: np.ndarray) -> np.ndarray:
+        """
+        Calculate Tanimoto similarities between a query molecule fingerprint and a set of precomputed fingerprints.
+        Args:
+            query: np.ndarray representing the fingerprint of the query molecule
+        Returns:
+            Array of Tanimoto similarities
+        """
+        query_fp_bit_vect = self.numpy_to_bitvect(query_fp)
+        similarities = np.array(
+            DataStructs.BulkTanimotoSimilarity(query_fp_bit_vect, self.fingerprints)
+        )
+        return similarities
+
+    def precompute_fingerprints(self, smiles_list: List[str]) -> List[ExplicitBitVect]:
+        """Precompute fingerprints for the given list of SMILES strings."""
+        fps = self.featurizer.featurize(smiles_list)
+        return [self.numpy_to_bitvect(fp) for fp in fps]
+
+    def numpy_to_bitvect(self, np_array: np.ndarray) -> ExplicitBitVect:
+        """
+        Convert a numpy array fingerprint to an RDKit ExplicitBitVect object.
+        Args:
+            np_array: Numpy array containing binary fingerprint data
+        Returns:
+            ExplicitBitVect object
+        """
+        bitvect = DataStructs.ExplicitBitVect(len(np_array))
+        on_bits = np.where(np_array > 0)[0].tolist()
+        bitvect.SetBitsFromList(on_bits)
+        return bitvect


### PR DESCRIPTION
This PR:
* Adds comments and cleans up `src/data/split.py`. As it turns out, the scaffold splitter was already implemented some time ago, so I just checked if t works as intended.
* Adds a `TanimotoCalculator` class which calculates tanimoto distances (on ECFP fingerprints by default, but can use any featurizer compatible with FeaturizerBase) between a query molecule and a given set of molecules.
* Adds a script for processing datasets to yield subsets that contain only the molecules with tanimoto distance less or more than a given threshold (in relation to some other set of molecules, ex. the testing set of a ML task).